### PR TITLE
Fix homepage paragraph spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@ layout: default
   #left_col {
   float:left;
   width:75%;
+  padding-right:30px;
+  box-sizing:border-box;
   }
+  #left_col p { margin-bottom:1em; }
+  #left_col p:last-child { margin-bottom:0; }
+  #left_col p:first-child { font-size:1.15em; }
   #right_col {
   float:right;
   width:25%;


### PR DESCRIPTION
## Summary
The homepage intro paragraphs were rendering as one undifferentiated block. Cause: the global `* { margin: 0; padding: 0; }` reset in `main.css` strips `<p>` margins, and paragraph spacing is only restored inside `.post-content` (blog posts) — the homepage isn't a post.

Fix (scoped to `#left_col` via the existing inline `<style>`):
- `#left_col p { margin-bottom: 1em; }` — restores inter-paragraph spacing.
- `#left_col p:last-child { margin-bottom: 0; }` — no trailing gap.
- `#left_col p:first-child { font-size: 1.15em; }` — lead line stands out.
- `padding-right: 30px` — gutter between text and photo.

Verified via a standalone preview inlining the real `main.css` (no Jekyll/browser available in the dev env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)